### PR TITLE
Expose .port method for inspection

### DIFF
--- a/cader.js
+++ b/cader.js
@@ -36,7 +36,7 @@ function chain(fn) {
 }
 
 
-function copy(object) {
+function port(object) {
   if (object === vacant) throw new Error("Won't serialize: " + object)
   var serial = JSON.stringify(object)
   if (serial === vacant) throw new Error("Couldn't serialize: " + object)
@@ -44,9 +44,9 @@ function copy(object) {
 }
 
 function save(hash, incoming) {
-  var copied = copy(incoming)
-  Object.keys(copied).forEach(function(key) {
-    var value = copied[key]
+  var fresh = port(incoming)
+  Object.keys(fresh).forEach(function(key) {
+    var value = fresh[key]
     value = sure(value)
     value = format(value)
     set(hash, key, value)
@@ -114,6 +114,7 @@ defineEnum(model, "clone", result(clone))
 defineEnum(model, "freeze", chain(freeze))
 defineEnum(model, "bond", result(bond))
 defineEnum(model, "has", result(has))
+defineEnum(model, "port", result(port))
 defineEnum(model, "save", chain(save))
 
 Object.seal(model);

--- a/test.js
+++ b/test.js
@@ -6,6 +6,10 @@ const c1 = new cader
 const c2 = new cader
 const c3 = cader()
 const c4 = cader()
+const batch = Object.freeze({
+  "a1": "a one",
+  "b2": "b two",
+})
 
 assert.ok(!!model, true)
 assert.ok(c1 instanceof cader)
@@ -65,6 +69,9 @@ c2.save({
   "TallPodium": c2.bond("Podium px2 py4"),
   "WidePodium": c2.bond("Podium px4 py2"),
 })
+
+assert.deepEqual((new cader).port(), {})
+assert.deepEqual((new cader).save(batch).port(), batch)
 
 console.log("Methods:", Object.keys(model))
 console.log("Tests passed =)")


### PR DESCRIPTION
I considered `.keys` only but this seems super helpful and we already have the internal for it