### PR TITLE
"saved" seems friendlier in error message

### DIFF
--- a/cader.js
+++ b/cader.js
@@ -90,7 +90,7 @@ function sure(value) {
 
 function set(hash, key, value) {
   if (ssv.count(key) !== 1) throw new Error("Key must be a single token")
-  if (has(hash, key)) throw new Error("Already set: " + key)
+  if (has(hash, key)) throw new Error("Already saved: " + key)
   if (Object.isFrozen(hash)) throw new Error("Frozen. Consider: .clone()")
   defineEnum(hash, key, sure(value))
 }


### PR DESCRIPTION
> ~Already set:~

> Already saved: