### PR TITLE
Provide pair method

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ const feature = library.clone() // new instance has access to atoms from library
 feature.save({/* ... */})  // can save more atoms if unique from library atoms
 ```
 
+### `.pair(mate)`
+
+- pair instance with another instance
+- shortcut for `.clone().save(mate.port())`
+- will `throw` if there are conflicts
+- `@return` clone containing atoms from both
+
+```js
+const shape = new cader
+const paint = new cader
+/* ... */
+const super = shape.pair(paint)
+```
+
 ### `.help()`
 
 - log [helpful info](https://github.com/ryanve/cader/pull/22) about an instance including atom mapping and methods

--- a/cader.js
+++ b/cader.js
@@ -85,6 +85,10 @@ function clone(hash) {
   return (new cader).save(hash)
 }
 
+function pair(hash, mate) {
+  return clone(hash).save(mate.port())
+}
+
 function sure(value) {
   if (typeof value != "string") throw new TypeError("Values must be strings")
   return value
@@ -119,6 +123,7 @@ defineEnum(model, "freeze", chain(freeze))
 defineEnum(model, "bond", result(bond))
 defineEnum(model, "has", result(has))
 defineEnum(model, "help", chain(help))
+defineEnum(model, "pair", result(pair))
 defineEnum(model, "port", result(port))
 defineEnum(model, "save", chain(save))
 

--- a/test.js
+++ b/test.js
@@ -10,6 +10,10 @@ const batch = Object.freeze({
   "a1": "a one",
   "b2": "b two",
 })
+const c5 = cader().save({ A: "a" })
+const c6 = cader().save({ A: "a" })
+const c7 = cader().save({ B: "b" })
+const c8 = cader().save({ C: "c" })
 
 assert.ok(!!model, true)
 assert.ok(c1 instanceof cader)
@@ -59,6 +63,14 @@ assert.strictEqual(c1.freeze(), c1)
 assert.ok(c1.clone() instanceof cader)
 assert.strictEqual(c1.clone().fuse("Gold"), c1.fuse("Gold"))
 assert.strictEqual(c1.clone().fuse("Podium"), c1.fuse("Podium"))
+
+assert.throws(() => c5.pair(c6))
+assert.strictEqual(c5.pair(c7).fuse("A"), c5.fuse("A"))
+assert.strictEqual(c5.pair(c7).fuse("B"), c7.fuse("B"))
+assert.deepEqual(
+  c5.pair(c7).pair(c8).port(),
+  Object.assign(c5.port(), c7.port(), c8.port())
+)
 
 c2.save({
   "Gold": "1st save-test value",


### PR DESCRIPTION
### `.pair(mate)`

- pair instance with another instance
- shortcut for `.clone().save(mate.port())`
- will `throw` if there are conflicts
- `@return` clone containing atoms from both

```js
const shape = new cader
const paint = new cader
/* ... */
const super = shape.pair(paint)
```